### PR TITLE
try to add a document_symbols handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Language Server for **proto3** files. It uses tree-sitter parser for all opera
 - [x] Hover
 - [x] Go to definition
 - [x] Diagnostics
+- [x] Document symbols outline for message and enums
 
 ## Installation
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,5 @@
+use std::unreachable;
+
 use async_lsp::lsp_types::{
     Diagnostic, DiagnosticSeverity, DocumentSymbol, Location, MarkedString, Position,
     PublishDiagnosticsParams, Range, SymbolKind, Url,
@@ -40,10 +42,6 @@ impl DocumentSymbolTreeBuilder {
     }
 
     fn build(self) -> Vec<DocumentSymbol> {
-        assert!(
-            self.stack.is_empty(),
-            "The symbol stack isn't empty which is a bug :("
-        );
         self.found
     }
 }
@@ -65,10 +63,7 @@ impl ProtoParser {
 }
 
 impl ParsedTree {
-    fn walk_and_collect_kinds<'a>(
-        cursor: &mut TreeCursor<'a>,
-        kinds: &[&str],
-    ) -> Vec<Node<'a>> {
+    fn walk_and_collect_kinds<'a>(cursor: &mut TreeCursor<'a>, kinds: &[&str]) -> Vec<Node<'a>> {
         let mut v = vec![];
 
         loop {
@@ -191,7 +186,7 @@ impl ParsedTree {
                 let kind = match node.kind() {
                     "message_name" => SymbolKind::STRUCT,
                     "enum_name" => SymbolKind::ENUM,
-                    _ => panic!("Should be impossible"),
+                    _ => unreachable!("unsupported symbol kind"),
                 };
                 let detail = self.find_preceding_comments(node.id(), content);
                 let message = node.parent().unwrap();
@@ -570,25 +565,6 @@ message Outer2 {
                 },
             )
         );
-        /*
-        assert_eq!(res[0].uri, Url::parse(url).unwrap());
-        assert_eq!(
-            res[0].range,
-            Range {
-                start: Position {
-                    line: 5,
-                    character: 12
-                },
-                end: Position {
-                    line: 5,
-                    character: 18
-                },
-            }
-        );
-
-        let res = tree.definition(&posinvalid, &url.parse().unwrap(), contents);
-        assert_eq!(res.len(), 0);
-        */
     }
 
     #[test]


### PR DESCRIPTION
started using this the lsp the other day and found it very helpful to jump from message-to-message. thanks!

i use https://github.com/hedyhli/outline.nvim and work with some massive proto files, so i thought it might be nice to be able to get an outline of the file in the outline view.

i'm not an expert with treesitter node walking nor language servers so there are probably several optimizations that could be made.

not sure if there's interest in this but I figured i would post it anyway.