### PR TITLE
fix: prefix `.` for fully qualified field names was not working

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -37,6 +37,8 @@ pub fn is_inner_identifier(s: &str) -> bool {
 }
 
 pub fn split_identifier_package(s: &str) -> (&str, &str) {
+    // trim beginning dots, some use `.` prefix for fully qualified field names
+    let s = s.trim_start_matches(".");
     if is_inner_identifier(s) || !s.contains('.') {
         return ("", s);
     }
@@ -74,6 +76,10 @@ mod test {
     fn test_split_identifier_package() {
         assert_eq!(
             split_identifier_package("com.book.Book"),
+            ("com.book", "Book")
+        );
+        assert_eq!(
+            split_identifier_package(".com.book.Book"),
             ("com.book", "Book")
         );
         assert_eq!(


### PR DESCRIPTION
Sometimes, user prefer to use `.` as prefix for fully qualified field names. This fixes the `split_package_identifier` to take into account this during splitting.

This potentially fixes: #31