### PR TITLE
Formatter uses stdin instead of filepath

### DIFF
--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -3,6 +3,6 @@ use async_lsp::lsp_types::{Range, TextEdit};
 pub mod clang;
 
 pub trait ProtoFormatter: Sized {
-    fn format_document(&self, content: &str) -> Option<Vec<TextEdit>>;
-    fn format_document_range(&self, r: &Range, content: &str) -> Option<Vec<TextEdit>>;
+    fn format_document(&self, filename: &str, content: &str) -> Option<Vec<TextEdit>>;
+    fn format_document_range(&self, r: &Range, filename: &str, content: &str) -> Option<Vec<TextEdit>>;
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -375,7 +375,7 @@ impl LanguageServer for ProtoLanguageServer {
         let response = self
             .state
             .get_formatter()
-            .and_then(|f| f.format_document(content.as_str()));
+            .and_then(|f| f.format_document(uri.path(), content.as_str()));
 
         Box::pin(async move { Ok(response) })
     }
@@ -390,7 +390,7 @@ impl LanguageServer for ProtoLanguageServer {
         let response = self
             .state
             .get_formatter()
-            .and_then(|f| f.format_document_range(&params.range, content.as_str()));
+            .and_then(|f| f.format_document_range(&params.range, uri.path(), content.as_str()));
 
         Box::pin(async move { Ok(response) })
     }


### PR DESCRIPTION
In the current version, at least on Nvim and OSX, .clang-format in the root of the repo was being ignored because clang-format looks for a config file relative to the source file, not the working directory.

This change allows .clang-format in the root of a workspace to be properly picked up with the addition of the assume-filename flag.