### PR TITLE
fix: nothing works in a file without a package

### DIFF
--- a/sample/test.proto
+++ b/sample/test.proto
@@ -9,3 +9,17 @@ message SomeMessage {
 
   CustomType another = 2;
 }
+
+message A {
+  // B is a b
+  message B {
+
+  }
+
+  B b = 1;
+}
+
+message C {
+  A.B ab = 1;
+  A a = 2;
+}

--- a/sample/test.proto
+++ b/sample/test.proto
@@ -10,16 +10,16 @@ message SomeMessage {
   CustomType another = 2;
 }
 
-message A {
+message CapitalA {
   // B is a b
-  message B {
+  message CapitalB {
 
   }
 
-  B b = 1;
+ a.b.c.CapitalA.CapitalB b = 1;
 }
 
 message C {
-  A.B ab = 1;
-  A a = 2;
+  CapitalA.CapitalB ab = 1;
+  .a.b.c.CapitalA a = 2;
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,8 +17,7 @@ pub struct ProtolsConfig {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct FormatterConfig {
-}
+pub struct FormatterConfig {}
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(default)]
@@ -38,7 +37,7 @@ impl Default for PathConfig {
     fn default() -> Self {
         Self {
             clang_format: default_clang_format_path(),
-            protoc: default_protoc_path()
+            protoc: default_protoc_path(),
         }
     }
 }

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -149,8 +149,8 @@ impl WorkspaceProtoConfigs {
 mod test {
     use async_lsp::lsp_types::{Url, WorkspaceFolder};
     use insta::assert_yaml_snapshot;
-    use tempfile::tempdir;
     use std::path::PathBuf;
+    use tempfile::tempdir;
 
     use super::{CONFIG_FILE_NAMES, WorkspaceProtoConfigs};
 
@@ -263,13 +263,16 @@ mod test {
         let include_paths = ws.get_include_paths(&inworkspace).unwrap();
 
         // Check that CLI paths are included in the result
-        assert!(include_paths.iter().any(|p| p.ends_with("relative/path") || 
-                                        p == &PathBuf::from("/path/to/protos")));
-        
+        assert!(
+            include_paths
+                .iter()
+                .any(|p| p.ends_with("relative/path") || p == &PathBuf::from("/path/to/protos"))
+        );
+
         // The relative path should be resolved relative to the workspace
         let resolved_relative_path = tmpdir.path().join("relative/path");
         assert!(include_paths.contains(&resolved_relative_path));
-        
+
         // The absolute path should be included as is
         assert!(include_paths.contains(&PathBuf::from("/path/to/protos")));
     }

--- a/src/parser/definition.rs
+++ b/src/parser/definition.rs
@@ -11,6 +11,7 @@ impl ParsedTree {
         self.definition_impl(identifier, self.tree.root_node(), &mut results, content);
         results
     }
+
     fn definition_impl(
         &self,
         identifier: &str,

--- a/src/state.rs
+++ b/src/state.rs
@@ -67,9 +67,7 @@ impl ProtoLanguageState {
             .values()
             .filter(|tree| {
                 let content = self.get_content(&tree.uri);
-                tree.get_package_name(content.as_bytes())
-                    .unwrap_or(".")
-                    == package
+                tree.get_package_name(content.as_bytes()).unwrap_or(".") == package
             })
             .map(ToOwned::to_owned)
             .collect()

--- a/src/state.rs
+++ b/src/state.rs
@@ -68,7 +68,7 @@ impl ProtoLanguageState {
             .filter(|tree| {
                 let content = self.get_content(&tree.uri);
                 tree.get_package_name(content.as_bytes())
-                    .unwrap_or_default()
+                    .unwrap_or(".")
                     == package
             })
             .map(ToOwned::to_owned)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -37,7 +37,6 @@ pub fn is_inner_identifier(s: &str) -> bool {
 }
 
 pub fn split_identifier_package(s: &str) -> (&str, &str) {
-    // trim beginning dots, some use `.` prefix for fully qualified field names
     let s = s.trim_start_matches(".");
     if is_inner_identifier(s) || !s.contains('.') {
         return ("", s);

--- a/src/workspace/rename.rs
+++ b/src/workspace/rename.rs
@@ -23,7 +23,7 @@ impl ProtoLanguageState {
             .into_iter()
             .fold(HashMap::new(), |mut h, tree| {
                 let content = self.get_content(&tree.uri);
-                let package = tree.get_package_name(content.as_ref()).unwrap_or_default();
+                let package = tree.get_package_name(content.as_ref()).unwrap_or(".");
                 let mut old = identifier.to_string();
                 let mut new = new_text.to_string();
                 if current_package != package {
@@ -52,7 +52,7 @@ impl ProtoLanguageState {
             .into_iter()
             .fold(Vec::<Location>::new(), |mut v, tree| {
                 let content = self.get_content(&tree.uri);
-                let package = tree.get_package_name(content.as_ref()).unwrap_or_default();
+                let package = tree.get_package_name(content.as_ref()).unwrap_or(".");
                 let mut old = identifier.to_owned();
                 if current_package != package {
                     old = format!("{current_package}.{old}");

--- a/src/workspace/rename.rs
+++ b/src/workspace/rename.rs
@@ -26,11 +26,39 @@ impl ProtoLanguageState {
                 let package = tree.get_package_name(content.as_ref()).unwrap_or(".");
                 let mut old = identifier.to_string();
                 let mut new = new_text.to_string();
-                if current_package != package {
-                    old = format!("{current_package}.{old}");
-                    new = format!("{current_package}.{new}");
+                let mut v = vec![];
+
+                // Global scope: Reference by only . or within global directly
+                if current_package == "." {
+                    if package == "." {
+                        v.extend(tree.rename_field(&old, &new, content.as_str()));
+                    }
+
+                    old = format!(".{old}");
+                    new = format!(".{new}");
+
+                    v.extend(tree.rename_field(&old, &new, content.as_str()));
+
+                    if !v.is_empty() {
+                        h.insert(tree.uri.clone(), v);
+                    }
+                    return h;
                 }
-                let v = tree.rename_field(&old, &new, content.as_str());
+
+                let full_old = format!("{current_package}.{old}");
+                let full_new = format!("{current_package}.{new}");
+                let global_full_old = format!(".{current_package}.{old}");
+                let global_full_new = format!(".{current_package}.{new}");
+
+                // Current package: Reference by full or relative name or directly
+                if current_package == package {
+                    v.extend(tree.rename_field(&old, &new, content.as_str()));
+                }
+
+                // Otherwise, full reference
+                v.extend(tree.rename_field(&full_old, &full_new, content.as_str()));
+                v.extend(tree.rename_field(&global_full_old, &global_full_new, content.as_str()));
+
                 if !v.is_empty() {
                     h.insert(tree.uri.clone(), v);
                 }
@@ -54,10 +82,29 @@ impl ProtoLanguageState {
                 let content = self.get_content(&tree.uri);
                 let package = tree.get_package_name(content.as_ref()).unwrap_or(".");
                 let mut old = identifier.to_owned();
-                if current_package != package {
-                    old = format!("{current_package}.{old}");
+                // Global scope: Reference by only . or within global directly
+                if current_package == "." {
+                    if package == "." {
+                        v.extend(tree.reference_field(&old, content.as_str()));
+                    }
+
+                    old = format!(".{old}");
+                    v.extend(tree.reference_field(&old, content.as_str()));
+
+                    return v;
                 }
-                v.extend(tree.reference_field(&old, content.as_str()));
+
+                let full_old = format!("{current_package}.{old}");
+                let global_full_old = format!(".{current_package}.{old}");
+
+                // Current package: Reference by full or relative name or directly
+                if current_package == package {
+                    v.extend(tree.reference_field(&old, content.as_str()));
+                }
+
+                // Otherwise, full reference
+                v.extend(tree.reference_field(&full_old, content.as_str()));
+                v.extend(tree.reference_field(&global_full_old, content.as_str()));
                 v
             });
         if r.is_empty() { None } else { Some(r) }


### PR DESCRIPTION
Prior to this, a proto file without a package declaration didn't supported any operation as parser required that a package be present. For missing package we now consider . as package