### PR TITLE
feat: Add support for relative package resolution

### DIFF
--- a/src/workspace/definition.rs
+++ b/src/workspace/definition.rs
@@ -34,12 +34,22 @@ impl ProtoLanguageState {
                     package = curr_package;
                 }
 
-                self.get_trees_for_package(package)
-                    .into_iter()
-                    .fold(vec![], |mut v, tree| {
-                        v.extend(tree.definition(identifier, self.get_content(&tree.uri)));
-                        v
-                    })
+                let mut trees = vec![];
+
+                // If package != curr_package, either identifier is from a completely new package
+                // or relative package from within. As per name resolution first resolve relative
+                // packages, add all relative trees in search list
+                if curr_package != package {
+                    let fullpackage = format!("{curr_package}.{package}");
+                    trees.append(&mut self.get_trees_for_package(&fullpackage));
+                }
+
+                // Add all direct package trees
+                trees.append(&mut self.get_trees_for_package(package));
+                trees.into_iter().fold(vec![], |mut v, tree| {
+                    v.extend(tree.definition(identifier, self.get_content(&tree.uri)));
+                    v
+                })
             }
         }
     }

--- a/src/workspace/input/a.proto
+++ b/src/workspace/input/a.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package com.workspace;
 
 import "c.proto";
+import "b.proto";
 import "inner/x.proto";
 
 // A Book is a book

--- a/src/workspace/input/inner/secret/y.proto
+++ b/src/workspace/input/inner/secret/y.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package com.super.secret;
+package com.inner.secret;
 
 // SomeSecret is a real secret with hidden string
 message SomeSecret {

--- a/src/workspace/input/inner/x.proto
+++ b/src/workspace/input/inner/x.proto
@@ -7,6 +7,7 @@ import "inner/secret/y.proto";
 // Why is a reason with secret
 message Why {
    string reason = 1;
-   com.super.secret.SomeSecret secret = 2;
+   .com.inner.secret.SomeSecret secret = 2;
+   secret.SomeSecret secret2 = 3;
 }
 

--- a/src/workspace/snapshots/protols__workspace__hover__test__workspace_test_hover-8.snap
+++ b/src/workspace/snapshots/protols__workspace__hover__test__workspace_test_hover-8.snap
@@ -1,7 +1,6 @@
 ---
 source: src/workspace/hover.rs
-expression: "state.hover(&ipath, \"com.workspace\",\nHoverables::Identifier(\"com.super.secret.SomeSecret\".to_string()))"
-snapshot_kind: text
+expression: "state.hover(&ipath, \"com.inner\",\nHoverables::Identifier(\".com.inner.secret.SomeSecret\".to_string()))"
 ---
 kind: markdown
-value: "`SomeSecret` message or enum type, package: `com.super.secret`\n---\nSomeSecret is a real secret with hidden string"
+value: "`SomeSecret` message or enum type, package: `com.inner.secret`\n---\nSomeSecret is a real secret with hidden string"

--- a/src/workspace/snapshots/protols__workspace__hover__test__workspace_test_hover-9.snap
+++ b/src/workspace/snapshots/protols__workspace__hover__test__workspace_test_hover-9.snap
@@ -1,7 +1,6 @@
 ---
 source: src/workspace/hover.rs
-expression: "state.hover(&ipath, \"com.workspace\",\nHoverables::Identifier(\"com.super.secret.SomeSecret\".to_string()))"
-snapshot_kind: text
+expression: "state.hover(&ipath, \"com.inner\",\nHoverables::Identifier(\"secret.SomeSecret\".to_string()))"
 ---
 kind: markdown
-value: "`SomeSecret` message or enum type, package: `com.super.secret`\n---\nSomeSecret is a real secret with hidden string"
+value: "`SomeSecret` message or enum type, package: `secret`\n---\nSomeSecret is a real secret with hidden string"

--- a/src/workspace/snapshots/protols__workspace__rename__test__reference-2.snap
+++ b/src/workspace/snapshots/protols__workspace__rename__test__reference-2.snap
@@ -1,13 +1,12 @@
 ---
 source: src/workspace/rename.rs
-expression: "state.reference_fields(\"com.workspace\", \"Author.Address\")"
-snapshot_kind: text
+expression: "state.reference_fields(\"com.workspace\", \"Author.Address\",\nPathBuf::from(\"src/workspace/input\"), None)"
 ---
 - uri: "file://input/a.proto"
   range:
     start:
-      line: 10
+      line: 11
       character: 3
     end:
-      line: 10
+      line: 11
       character: 17

--- a/src/workspace/snapshots/protols__workspace__rename__test__reference.snap
+++ b/src/workspace/snapshots/protols__workspace__rename__test__reference.snap
@@ -1,13 +1,12 @@
 ---
 source: src/workspace/rename.rs
-expression: "state.reference_fields(\"com.workspace\", \"Author\")"
-snapshot_kind: text
+expression: "state.reference_fields(\"com.workspace\", \"Author\",\nPathBuf::from(\"src/workspace/input\"), None)"
 ---
 - uri: "file://input/a.proto"
   range:
     start:
-      line: 9
+      line: 10
       character: 3
     end:
-      line: 9
+      line: 10
       character: 9

--- a/src/workspace/snapshots/protols__workspace__rename__test__rename-2.snap
+++ b/src/workspace/snapshots/protols__workspace__rename__test__rename-2.snap
@@ -1,14 +1,13 @@
 ---
 source: src/workspace/rename.rs
-expression: "state.rename_fields(\"com.workspace\", \"Author.Address\", \"Author.Location\")"
-snapshot_kind: text
+expression: "state.rename_fields(\"com.workspace\", \"Author.Address\", \"Author.Location\",\nPathBuf::from(\"src/workspace/input\"), None)"
 ---
 "file://input/a.proto":
   - range:
       start:
-        line: 10
+        line: 11
         character: 3
       end:
-        line: 10
+        line: 11
         character: 17
     newText: Author.Location

--- a/src/workspace/snapshots/protols__workspace__rename__test__rename-3.snap
+++ b/src/workspace/snapshots/protols__workspace__rename__test__rename-3.snap
@@ -1,14 +1,13 @@
 ---
 source: src/workspace/rename.rs
-expression: "state.rename_fields(\"com.utility\", \"Foobar.Baz\", \"Foobar.Baaz\")"
-snapshot_kind: text
+expression: "state.rename_fields(\"com.utility\", \"Foobar.Baz\", \"Foobar.Baaz\",\nPathBuf::from(\"src/workspace/input\"), None)"
 ---
 "file://input/a.proto":
   - range:
       start:
-        line: 11
+        line: 12
         character: 3
       end:
-        line: 11
+        line: 12
         character: 25
     newText: com.utility.Foobar.Baaz

--- a/src/workspace/snapshots/protols__workspace__rename__test__rename.snap
+++ b/src/workspace/snapshots/protols__workspace__rename__test__rename.snap
@@ -1,22 +1,21 @@
 ---
 source: src/workspace/rename.rs
-expression: "state.rename_fields(\"com.workspace\", \"Author\", \"Writer\")"
-snapshot_kind: text
+expression: "state.rename_fields(\"com.workspace\", \"Author\", \"Writer\",\nPathBuf::from(\"src/workspace/input\"), None)"
 ---
 "file://input/a.proto":
   - range:
       start:
-        line: 9
+        line: 10
         character: 3
       end:
-        line: 9
+        line: 10
         character: 9
     newText: Writer
   - range:
       start:
-        line: 10
+        line: 11
         character: 3
       end:
-        line: 10
+        line: 11
         character: 17
     newText: Writer.Address


### PR DESCRIPTION
fixes #75

Prior to this `protols` could not resolve relative package names, this fixes it and now LSP should be able to properly jump/hover and find references/rename even in packages with field name relative to current package.