### PR TITLE
feat: add reloadable LSP logging and setTrace support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,10 +1315,14 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1.47", features = ["time", "full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tower = "0.5"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tree-sitter = "0.26"
 tracing-appender = "0.2"
 tree-sitter-proto = "0.4"

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,190 @@
+use async_lsp::lsp_types::{LogMessageParams, MessageType, TraceValue};
+use tokio::sync::mpsc;
+use tracing::{Level, Subscriber};
+use tracing_subscriber::{EnvFilter, Layer, Registry, filter::Directive, prelude::*, reload};
+
+/// A `tracing` layer that forwards log events to an LSP client via a channel.
+pub struct ClientLogger {
+    /// The sender half of a channel connected to the LSP client's log message handler.
+    pub tx: mpsc::Sender<LogMessageParams>,
+}
+
+impl<S: Subscriber> Layer<S> for ClientLogger {
+    fn enabled(
+        &self,
+        metadata: &tracing::Metadata<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) -> bool {
+        // Filter: only log events from our crate, or errors from any crate.
+        metadata.target().starts_with(env!("CARGO_PKG_NAME"))
+            || *metadata.level() <= tracing::Level::ERROR
+    }
+
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        use tracing::field::{Field, Visit};
+
+        struct MessageVisitor {
+            message: String,
+            fields: String,
+        }
+        impl Visit for MessageVisitor {
+            fn record_str(&mut self, field: &Field, value: &str) {
+                if field.name() == "message" {
+                    self.message.push_str(value);
+                } else {
+                    self.fields
+                        .push_str(&format!(" {}={}", field.name(), value));
+                }
+            }
+
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                if field.name() == "message" {
+                    if self.message.is_empty() {
+                        self.message = format!("{:?}", value);
+                    }
+                } else {
+                    self.fields
+                        .push_str(&format!(" {}={:?}", field.name(), value));
+                }
+            }
+        }
+
+        let mut visitor = MessageVisitor {
+            message: String::with_capacity(256),
+            fields: String::with_capacity(256),
+        };
+
+        event.record(&mut visitor);
+
+        let metadata = event.metadata();
+        let target = metadata.target().split("::").last().unwrap_or("");
+
+        let full_text = if visitor.fields.is_empty() {
+            visitor.message
+        } else {
+            format!("{} | fields:{}", visitor.message, visitor.fields)
+        };
+
+        let message = format!("[{}] {}", target, full_text);
+
+        let typ = match *metadata.level() {
+            tracing::Level::ERROR => MessageType::ERROR,
+            tracing::Level::WARN => MessageType::WARNING,
+            tracing::Level::INFO => MessageType::INFO,
+            tracing::Level::DEBUG => MessageType::LOG,
+            _ => MessageType::LOG,
+        };
+
+        let _ = self.tx.try_send(LogMessageParams { typ, message });
+    }
+}
+
+/// Handle to dynamically reload the log filter at runtime.
+pub type LogReloadHandle = reload::Handle<EnvFilter, Registry>;
+
+/// Installs the global tracing subscriber with a reloadable filter and the LSP logger.
+///
+/// Returns a [`self::LogReloadHandle`] that can be used to update the log level.
+pub fn install(tx: mpsc::Sender<LogMessageParams>) -> LogReloadHandle {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into());
+
+    let (filter_layer, reload_handle) = reload::Layer::new(filter);
+
+    let lsp_layer = ClientLogger { tx };
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(lsp_layer)
+        .init();
+
+    reload_handle
+}
+
+/// Updates the log filter level based on the provided LSP [`TraceValue`].
+///
+/// Mapping:
+///
+/// - [`Verbose`] -> `trace`
+/// - [`Messages`] -> `debug`
+/// - [`Off`] -> `info`
+///
+/// Note: We use standard `window/logMessage` for all levels. While the LSP spec
+/// mentions `$/logTrace`, most clients have better support for `window/logMessage`.
+///
+/// [`Verbose`]: TraceValue::Verbose
+/// [`Messages`]: TraceValue::Messages
+/// [`Off`]: TraceValue::Off
+pub fn update_level(handle: &LogReloadHandle, value: TraceValue) {
+    let pkg_name = env!("CARGO_PKG_NAME");
+
+    let level = match value {
+        TraceValue::Verbose => Level::TRACE,
+        TraceValue::Messages => Level::DEBUG,
+        TraceValue::Off => Level::INFO,
+    };
+
+    // Construct directives: "warn" for the whole world, "pkg=level" for us
+    let global_directive = Level::WARN.into();
+    let pkg_directive = format!("{}={}", pkg_name, level)
+        .parse::<Directive>()
+        .expect("Failed to parse log directive");
+
+    let filter = EnvFilter::default()
+        .add_directive(global_directive)
+        .add_directive(pkg_directive);
+
+    if let Err(e) = handle.modify(|f| *f = filter) {
+        tracing::error!("failed to reload log filter: {e}");
+    } else {
+        tracing::info!("logger set to: {level}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_client_logger_formatting() {
+        const TARGET: &str = "test_target";
+        const MESSAGE: &str = "initialized session";
+        let field_name = "user_id";
+        let field_value = 42;
+
+        let (tx, mut rx) = mpsc::channel(10);
+        let logger = ClientLogger { tx };
+        let subscriber = Registry::default().with(logger);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        tracing::error!(target: TARGET, user_id = field_value, MESSAGE);
+
+        let msg = rx.try_recv().expect("log message should be received");
+
+        // Assertions for the formatted message
+        assert_eq!(msg.typ, MessageType::ERROR);
+
+        assert!(msg.message.contains(MESSAGE));
+
+        let expected_field = format!("{}={}", field_name, field_value);
+        assert!(msg.message.contains(&expected_field));
+
+        assert!(msg.message.contains(&format!("[{}]", TARGET)));
+    }
+
+    #[test]
+    fn test_update_level_mapping() {
+        let filter = EnvFilter::new("info");
+        let (layer, handle) = reload::Layer::new(filter);
+        let _subscriber = Registry::default().with(layer);
+
+        // Ensure that calling update_level for different TraceValues doesn't panic
+        // and executes the mapping logic correctly.
+        update_level(&handle, TraceValue::Verbose);
+        update_level(&handle, TraceValue::Messages);
+        update_level(&handle, TraceValue::Off);
+    }
+}

--- a/src/log.rs
+++ b/src/log.rs
@@ -4,6 +4,7 @@ use tracing::{
     Level, Subscriber,
     field::{Field, Visit},
 };
+use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{
     EnvFilter, Layer, Registry, filter::Directive, layer::SubscriberExt, reload,
     util::SubscriberInitExt,
@@ -91,22 +92,37 @@ impl<S: Subscriber> Layer<S> for ClientLogger {
 /// Handle to dynamically reload the log filter at runtime.
 pub type LogReloadHandle = reload::Handle<EnvFilter, Registry>;
 
-/// Installs the global tracing subscriber with a reloadable filter and the LSP logger.
-///
-/// Returns a [`self::LogReloadHandle`] that can be used to update the log level.
-pub fn install(tx: mpsc::Sender<LogMessageParams>) -> LogReloadHandle {
+/// Installs the global tracing subscriber with a reloadable filter, the LSP logger, 
+/// and a file-based backup logger.
+/// 
+/// Returns a tuple containing:
+/// 
+/// 1. A [`self::LogReloadHandle`] to dynamically update the log level.
+/// 2. A [`WorkerGuard`] that must be kept alive in the main function to ensure 
+///    non-blocking file logging continues.
+pub fn install(tx: mpsc::Sender<LogMessageParams>) -> (LogReloadHandle, WorkerGuard) {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into());
 
     let (filter_layer, reload_handle) = reload::Layer::new(filter);
 
     let lsp_layer = ClientLogger { tx };
 
+    let dir = std::env::temp_dir();
+    eprintln!("file logging at directory: {dir:?}");
+    let file_appender = tracing_appender::rolling::daily(dir, "protols.log");
+    let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
     tracing_subscriber::registry()
         .with(filter_layer)
         .with(lsp_layer)
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(non_blocking),
+        )
         .init();
 
-    reload_handle
+    (reload_handle, guard)
 }
 
 /// Updates the log filter level based on the provided LSP [`TraceValue`].

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,6 +1,9 @@
 use async_lsp::lsp_types::{LogMessageParams, MessageType, TraceValue};
 use tokio::sync::mpsc;
-use tracing::{Level, Subscriber};
+use tracing::{
+    Level, Subscriber,
+    field::{Field, Visit},
+};
 use tracing_subscriber::{
     EnvFilter, Layer, Registry, filter::Directive, layer::SubscriberExt, reload,
     util::SubscriberInitExt,
@@ -10,6 +13,33 @@ use tracing_subscriber::{
 pub struct ClientLogger {
     /// The sender half of a channel connected to the LSP client's log message handler.
     pub tx: mpsc::Sender<LogMessageParams>,
+}
+
+struct MessageVisitor {
+    message: String,
+    fields: String,
+}
+
+impl Visit for MessageVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message.push_str(value);
+        } else {
+            self.fields
+                .push_str(&format!(" {}={}", field.name(), value));
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            if self.message.is_empty() {
+                self.message = format!("{:?}", value);
+            }
+        } else {
+            self.fields
+                .push_str(&format!(" {}={:?}", field.name(), value));
+        }
+    }
 }
 
 impl<S: Subscriber> Layer<S> for ClientLogger {
@@ -28,34 +58,6 @@ impl<S: Subscriber> Layer<S> for ClientLogger {
         event: &tracing::Event<'_>,
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
-        use tracing::field::{Field, Visit};
-
-        struct MessageVisitor {
-            message: String,
-            fields: String,
-        }
-        impl Visit for MessageVisitor {
-            fn record_str(&mut self, field: &Field, value: &str) {
-                if field.name() == "message" {
-                    self.message.push_str(value);
-                } else {
-                    self.fields
-                        .push_str(&format!(" {}={}", field.name(), value));
-                }
-            }
-
-            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-                if field.name() == "message" {
-                    if self.message.is_empty() {
-                        self.message = format!("{:?}", value);
-                    }
-                } else {
-                    self.fields
-                        .push_str(&format!(" {}={:?}", field.name(), value));
-                }
-            }
-        }
-
         let mut visitor = MessageVisitor {
             message: String::with_capacity(256),
             fields: String::with_capacity(256),

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,7 +1,10 @@
 use async_lsp::lsp_types::{LogMessageParams, MessageType, TraceValue};
 use tokio::sync::mpsc;
 use tracing::{Level, Subscriber};
-use tracing_subscriber::{EnvFilter, Layer, Registry, filter::Directive, prelude::*, reload};
+use tracing_subscriber::{
+    EnvFilter, Layer, Registry, filter::Directive, layer::SubscriberExt, reload,
+    util::SubscriberInitExt,
+};
 
 /// A `tracing` layer that forwards log events to an LSP client via a channel.
 pub struct ClientLogger {

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -11,18 +11,18 @@ use async_lsp::lsp_types::{
     GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverContents, HoverParams,
     HoverProviderCapability, InitializeParams, InitializeResult, Location, MarkupContent,
     MarkupKind, OneOf, PrepareRenameResponse, ReferenceParams, RenameFilesParams, RenameOptions,
-    RenameParams, ServerCapabilities, ServerInfo, TextDocumentPositionParams,
+    RenameParams, ServerCapabilities, ServerInfo, SetTraceParams, TextDocumentPositionParams,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Url, WorkspaceEdit,
     WorkspaceFileOperationsServerCapabilities, WorkspaceFoldersServerCapabilities,
     WorkspaceServerCapabilities, WorkspaceSymbolParams, WorkspaceSymbolResponse,
 };
-use async_lsp::{LanguageClient, ResponseError};
+use async_lsp::{Error, LanguageClient, ResponseError};
 use futures::future::BoxFuture;
 use serde_json::Value;
 
-use crate::docs;
 use crate::formatter::ProtoFormatter;
 use crate::server::ProtoLanguageServer;
+use crate::{docs, log};
 
 impl ProtoLanguageServer {
     pub(super) fn initialize(
@@ -571,6 +571,13 @@ impl ProtoLanguageServer {
                 error!(uri = file.uri, "failed to parse uri");
             }
         }
+        ControlFlow::Continue(())
+    }
+
+    /// Handles the `$/setTrace` notification to dynamically update log verbosity.
+    pub(super) fn set_trace(&mut self, params: SetTraceParams) -> ControlFlow<Result<(), Error>> {
+        log::update_level(&self.log_handle, params.value);
+
         ControlFlow::Continue(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ async fn main() {
     let cli = Cli::parse();
 
     let (tx, mut rx) = tokio::sync::mpsc::channel(100);
-    let reload_handle = log::install(tx);
+    let (reload_handle, _log_guard) = log::install(tx);
 
     tracing::info!("server version: {}", env!("CARGO_PKG_VERSION"));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use async_lsp::LanguageClient;
 use async_lsp::client_monitor::ClientProcessMonitorLayer;
 use async_lsp::concurrency::ConcurrencyLayer;
 use async_lsp::panic::CatchUnwindLayer;
@@ -9,12 +10,12 @@ use clap::Parser;
 use const_format::concatcp;
 use server::{ProtoLanguageServer, TickEvent};
 use tower::ServiceBuilder;
-use tracing::Level;
 
 mod config;
 mod context;
 mod docs;
 mod formatter;
+mod log;
 mod lsp;
 mod nodekind;
 mod parser;
@@ -56,29 +57,35 @@ const BUILD_INFO: &str = concatcp!(
 async fn main() {
     let cli = Cli::parse();
 
-    let dir = std::env::temp_dir();
-    eprintln!("file logging at directory: {dir:?}");
-
-    let file_appender = tracing_appender::rolling::daily(dir.clone(), "protols.log");
-    let file_appender = tracing_appender::non_blocking(file_appender);
-
-    tracing_subscriber::fmt()
-        .with_max_level(Level::INFO)
-        .with_ansi(false)
-        .with_writer(file_appender.0)
-        .init();
-
-    let fallback_include_path = FALLBACK_INCLUDE_PATH.map(Into::into);
+    let (tx, mut rx) = tokio::sync::mpsc::channel(100);
+    let reload_handle = log::install(tx);
 
     tracing::info!("server version: {}", env!("CARGO_PKG_VERSION"));
+
     let (server, _) = async_lsp::MainLoop::new_server(|client| {
+        let mut log_client = client.clone();
+
+        tokio::spawn(async move {
+            while let Some(params) = rx.recv().await {
+                let _ = log_client.log_message(params);
+            }
+        });
+
         tracing::info!("Using CLI options: {:?}", cli);
+
+        let include_paths = cli
+            .include_paths
+            .map(|ic| ic.into_iter().map(std::path::PathBuf::from).collect())
+            .unwrap_or_default();
+
+        let fallback_include_path = FALLBACK_INCLUDE_PATH.map(std::path::PathBuf::from);
+
         tracing::info!("Using fallback include path: {:?}", fallback_include_path);
+
         let router = ProtoLanguageServer::new_router(
             client.clone(),
-            cli.include_paths
-                .map(|ic| ic.into_iter().map(std::path::PathBuf::from).collect())
-                .unwrap_or_default(),
+            reload_handle,
+            include_paths,
             fallback_include_path,
         );
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,7 +4,7 @@ use async_lsp::{
         NumberOrString, ProgressParams, ProgressParamsValue,
         notification::{
             DidChangeTextDocument, DidCreateFiles, DidDeleteFiles, DidOpenTextDocument,
-            DidRenameFiles, DidSaveTextDocument, Exit,
+            DidRenameFiles, DidSaveTextDocument, Exit, SetTrace,
         },
         request::{
             Completion, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest,
@@ -21,11 +21,12 @@ use std::{
     thread,
 };
 
-use crate::{config::workspace::WorkspaceProtoConfigs, state::ProtoLanguageState};
+use crate::{config::workspace::WorkspaceProtoConfigs, log, state::ProtoLanguageState};
 
 pub struct TickEvent;
 pub struct ProtoLanguageServer {
     pub client: ClientSocket,
+    pub(crate) log_handle: log::LogReloadHandle,
     pub counter: i32,
     pub state: ProtoLanguageState,
     pub configs: WorkspaceProtoConfigs,
@@ -35,11 +36,13 @@ pub struct ProtoLanguageServer {
 impl ProtoLanguageServer {
     pub fn new_router(
         client: ClientSocket,
+        log_handle: log::LogReloadHandle,
         cli_include_paths: Vec<PathBuf>,
         fallback_include_path: Option<PathBuf>,
     ) -> Router<Self> {
         let mut router = Router::new(Self {
             client,
+            log_handle,
             counter: 0,
             state: ProtoLanguageState::new(),
             configs: WorkspaceProtoConfigs::new(cli_include_paths, fallback_include_path),
@@ -72,6 +75,7 @@ impl ProtoLanguageServer {
         router.request::<RangeFormatting, _>(|st, params| st.range_formatting(params));
 
         // Handling notification
+        router.notification::<SetTrace>(|st, params| st.set_trace(params));
         router.notification::<DidSaveTextDocument>(|st, params| st.did_save(params));
         router.notification::<DidOpenTextDocument>(|st, params| st.did_open(params));
         router.notification::<DidChangeTextDocument>(|st, params| st.did_change(params));


### PR DESCRIPTION
## Overview

This PR implements a more idiomatic LSP logging system. It shifts from static file-based logging to a dynamic, reloadable system that communicates directly with the LSP client.

neovim user experience (e.g. via `:messages`):

<img width="1286" height="262" alt="image" src="https://github.com/user-attachments/assets/696c9576-41a8-466b-bc7a-8cda603d8432" />

VS Code user experience (old output channel):

<img width="1211" height="287" alt="image" src="https://github.com/user-attachments/assets/c36dc83d-de18-4c0a-b36f-b2afce351c97" />

This will be even better when an Extension uses the modern [LogOutputChannel](https://code.visualstudio.com/api/references/vscode-api#window.createOutputChannel) (with `options: {log: true}`).

## Changes
- **New `log` module:** Added a custom tracing layer (`ClientLogger`) that forwards logs to the LSP client via an asynchronous channel.
- **Dynamic Filtering:** Integrated `tracing_subscriber::reload` to allow real-time log level updates.
- **LSP Protocol Support:** Implemented the [`$/setTrace`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#setTrace) notification handler in `ProtoLanguageServer`.
- **Unit Tests:** Added tests for the new logging layer and level-update logic.

## How to test

1. Run the server.
2. From the LSP client, send a [`$/setTrace`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#setTrace) notification with value `verbose`.
3. Observe the desired `TRACE` and `DEBUG` logs appearing in the editor's output channel.

## Compatibility

I've replaced the previous file-logging implementation to avoid cluttering. Please let me know if you would prefer to keep the file appender as a concurrent logging layer; I can easily add it back as an additional tracing layer.

Fixes #110
