### PR TITLE
ci: integrate devcontainer into CI and setup GHCR pre-builds

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE=mcr.microsoft.com/devcontainers/base:trixie
 
 FROM $BASE_IMAGE
 
+LABEL org.opencontainers.image.source=https://github.com/coder3101/protols
+
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y --no-install-recommends \
     protobuf-compiler \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
   "name": "Rust",
+  "image": "ghcr.io/coder3101/protols/devcontainer:latest",
   "build": {
     "dockerfile": "Dockerfile",
     "context": ".."

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,28 @@
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Run lints
-      run: cargo clippy --all-targets -- -D warnings
+    - uses: actions/checkout@v6
+    - name: Run CI in Dev Container
+      uses: devcontainers/ci@v0.3
+      with:
+        imageName: ghcr.io/${{ github.repository }}/devcontainer
+        cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
+        push: never
+        runCmd: |
+          export CARGO_TERM_COLOR=always &&
+          echo "::group::Check formatting" && cargo fmt --all -- --check && echo "::endgroup::" &&
+          echo "::group::Build" && cargo build --verbose && echo "::endgroup::" &&
+          echo "::group::Run tests" && cargo test --verbose && echo "::endgroup::" &&
+          echo "::group::Run lints" && cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/prebuild_devcontainer.yml
+++ b/.github/workflows/prebuild_devcontainer.yml
@@ -1,0 +1,31 @@
+name: Pre-build Dev Container
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.devcontainer/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'rust-toolchain.toml'
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Pre-build and push
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/${{ github.repository }}/devcontainer
+          cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
+          cacheTo: ghcr.io/${{ github.repository }}/devcontainer
+          push: filter
+          refFilterForPush: refs/heads/main
+          eventFilterForPush: push, workflow_dispatch

--- a/src/log.rs
+++ b/src/log.rs
@@ -92,13 +92,13 @@ impl<S: Subscriber> Layer<S> for ClientLogger {
 /// Handle to dynamically reload the log filter at runtime.
 pub type LogReloadHandle = reload::Handle<EnvFilter, Registry>;
 
-/// Installs the global tracing subscriber with a reloadable filter, the LSP logger, 
+/// Installs the global tracing subscriber with a reloadable filter, the LSP logger,
 /// and a file-based backup logger.
-/// 
+///
 /// Returns a tuple containing:
-/// 
+///
 /// 1. A [`self::LogReloadHandle`] to dynamically update the log level.
-/// 2. A [`WorkerGuard`] that must be kept alive in the main function to ensure 
+/// 2. A [`WorkerGuard`] that must be kept alive in the main function to ensure
 ///    non-blocking file logging continues.
 pub fn install(tx: mpsc::Sender<LogMessageParams>) -> (LogReloadHandle, WorkerGuard) {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into());


### PR DESCRIPTION
## Overview
This PR integrates our Dev Container into the CI/CD pipeline and sets up automated environment pre-builds. 

As discussed in #113, reusing the dev container environment would be great for CI. This is my first attempt at implementing this workflow.

Reference: <https://github.com/devcontainers/ci>

### Changes
- **Dev Container CI**: Integrated `devcontainers/ci` into the main workflow. Tests now run in a 1:1 environment compared to our local setup.
- **Pre-build Workflow**: Added a workflow to build and push the devcontainer image to GHCR. This caches our heavy environment to keep CI fast.
  - *Note:* After merging, the **Pre-build Dev Container** workflow should be manually triggered once on `main` to populate the registry.
- **Formatting & Quality**: 
  - Added `cargo fmt --check` as a mandatory CI step to maintain code style.
  - Applied `cargo fmt` to to fix the existing inconsistencies.
- **Automation**: Updated Dependabot to track `cargo` (with PR grouping), `github-actions`, and `docker` updates.

### How to verify
1. **CI Status**: The "Build and Test" workflow should pass (green) as the formatting issues have been fixed in this PR.
2. **Action Logs**: Check the "Run CI in Dev Container" step to see the grouped logs for Fmt, Build, Test, and Clippy.
3. **Pre-build**: Confirm the new workflow is available under the Actions tab for manual dispatch.

---
### Post-merge Configuration
Once this PR is merged and the first image is pushed:
1. Go to the **Packages** section on the repository home page.
2. Open the `devcontainer` package settings.
3. Ensure **Package Visibility** is set to **Public** (required for the CI to pull the image in PRs from forks).
4. (Optional) Check the **Packages** box in the "Include in the home page" settings (as shown in the attached screenshot) to make the image visible on the main page.
<img width="264" height="149" alt="image" src="https://github.com/user-attachments/assets/6e64234f-124e-4625-9f72-8b8f44ec09ba" />