### PR TITLE
ci: fix docker caching by switching to buildx driver

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
   "name": "Rust",
-  "image": "ghcr.io/coder3101/protols/devcontainer:latest",
   "build": {
     "dockerfile": "Dockerfile",
-    "context": ".."
+    "context": "..",
+    "cacheFrom": "ghcr.io/coder3101/protols/devcontainer:latest"
   },
   "features": {
     "ghcr.io/devcontainers/features/rust:1": {

--- a/.github/workflows/prebuild_devcontainer.yml
+++ b/.github/workflows/prebuild_devcontainer.yml
@@ -20,11 +20,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Pre-build and push
         uses: devcontainers/ci@v0.3
         with:
           imageName: ghcr.io/${{ github.repository }}/devcontainer
           cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
+          cacheTo: ghcr.io/${{ github.repository }}/devcontainer
           push: filter
           refFilterForPush: refs/heads/main
           eventFilterForPush: push, workflow_dispatch


### PR DESCRIPTION
## Overview

Fixes #123
This PR fixes the Docker caching issues.

### Proposed Changes
- Added [`docker/setup-buildx-action`](https://github.com/docker/setup-buildx-action) to enable the `docker-container` driver (required for registry caching).
- Restored `cacheTo` in the Pre-build workflow.

### 🛠 Action Required from the owner
To resolve the `403 Forbidden` errors and enable the cache, please:
1. Go to the **Package Settings** for `protols/devcontainer`.
2. Change **Package Visibility** to **Public**.
3. Under **Manage Actions access**, ensure the repository is added with at least **Read** access.

Once these steps are completed, the `cacheFrom` and `cacheTo` instructions will hopefully become fully operational.
