### PR TITLE
perf: enable aggressive release build optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,8 @@ const_format = "0.2"
 
 [dev-dependencies]
 insta = { version = "1.47", features = ["yaml", "redactions"] }
+
+[profile.release]
+strip = "debuginfo" # Removes heavy debug data but keeps function names for panic logs
+lto = true          # Enables Link-Time Optimization for cross-crate improvements
+codegen-units = 1   # Maximizes LLVM optimization passes


### PR DESCRIPTION
## Description
Closes #132

This PR optimizes the release profile settings in `Cargo.toml`. It introduces Link-Time Optimization (LTO), reduces code generation units to a single core for maximum compiler analysis, and strips heavy debug data while maintaining human-readable panic logs.

## How Was This Tested?
Tested locally inside the Devcontainer. Verified binary size differences using `ls -lh`. Drops from **6.9 MB** to **4.7 MB** (~32% reduction):

<img width="795" height="66" alt="image" src="https://github.com/user-attachments/assets/5158220e-afa7-409c-b618-ce0733f37a07" />

`cargo build --release` took **~46 seconds** with build optimizations vs. **~18 seconds** with no optimizations. I used `cargo clean` before each build command.