### PR TITLE
fix: file operations glob

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -54,7 +54,7 @@ impl ProtoLanguageServer {
         let file_operation_filers = vec![FileOperationFilter {
             scheme: Some(String::from("file")),
             pattern: FileOperationPattern {
-                glob: String::from("**/*.{proto}"),
+                glob: String::from("**/*.proto"),
                 matches: Some(FileOperationPatternKind::File),
                 ..Default::default()
             },


### PR DESCRIPTION
In the file operations pattern, `proto` was wrapped in brackets, which, for example, caused errors in `oil.nvim`.

`oil.nvim` error example (before commit):
<img width="973" height="230" alt="image" src="https://github.com/user-attachments/assets/440deadf-8f28-43ae-bc09-a7daba770789" />
